### PR TITLE
Migrate to MuPDF

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,15 +16,6 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
-      - name: Install Poppler
-        run: |
-          if [[ ${{ runner.os }} == "Linux" ]]; then
-            sudo apt-get update
-            sudo apt-get install poppler-utils
-          elif [[ ${{ runner.os }} == "macOS" ]]; then
-            brew update
-            brew install poppler
-          fi
       - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,11 +7,9 @@ authors = [
     { name = "Ryo Takahashi", email = "reiyw.setuve@gmail.com" }
 ]
 dependencies = [
-    "pdf2image>=1.4",
     "python-gyazo>=1.1",
     "click>=8.0",
-    "Pillow>=10.0.0",
-    "pypdf>=3.16.1",
+    "pymupdf>=1.24.7",
 ]
 readme = "README.md"
 requires-python = "~=3.8"
@@ -31,7 +29,6 @@ managed = true
 dev-dependencies = [
     "mypy~=0.991",
     "pytest~=7.2.0",
-    "types-pillow~=9.3.0.2",
     "types-click~=7.1.8",
     "pytest-mock~=3.10.0",
     "black~=22.10.0",

--- a/requirements-dev.lock
+++ b/requirements-dev.lock
@@ -5,37 +5,66 @@
 #   pre: false
 #   features: []
 #   all-features: false
+#   with-sources: false
+#   generate-hashes: false
 
 -e file:.
 attrs==23.1.0
+    # via pytest
 black==22.10.0
 certifi==2023.7.22
+    # via requests
 charset-normalizer==3.2.0
+    # via requests
 click==8.1.6
+    # via black
+    # via pdf2sb
 exceptiongroup==1.1.2
+    # via pytest
 idna==3.4
+    # via requests
 iniconfig==2.0.0
+    # via pytest
 markupsafe==2.1.3
+    # via werkzeug
 mypy==0.991
 mypy-extensions==1.0.0
+    # via black
+    # via mypy
 packaging==23.1
+    # via pytest
 pathspec==0.11.2
-pdf2image==1.16.3
-pillow==10.0.0
+    # via black
 platformdirs==3.10.0
+    # via black
 pluggy==1.2.0
-pypdf==3.16.1
+    # via pytest
+pymupdf==1.24.7
+    # via pdf2sb
+pymupdfb==1.24.6
+    # via pymupdf
 pytest==7.2.2
+    # via pytest-mock
 pytest-httpserver==1.0.8
 pytest-mock==3.10.0
 python-dateutil==2.8.2
+    # via python-gyazo
 python-gyazo==1.2.0
+    # via pdf2sb
 requests==2.31.0
+    # via python-gyazo
 ruff==0.0.282
 six==1.16.0
+    # via python-dateutil
 tomli==2.0.1
+    # via black
+    # via mypy
+    # via pytest
 types-click==7.1.8
-types-pillow==9.3.0.4
 typing-extensions==4.7.1
+    # via black
+    # via mypy
 urllib3==2.0.4
+    # via requests
 werkzeug==2.3.7
+    # via pytest-httpserver

--- a/requirements.lock
+++ b/requirements.lock
@@ -5,18 +5,29 @@
 #   pre: false
 #   features: []
 #   all-features: false
+#   with-sources: false
+#   generate-hashes: false
 
 -e file:.
 certifi==2023.7.22
+    # via requests
 charset-normalizer==3.2.0
+    # via requests
 click==8.1.6
+    # via pdf2sb
 idna==3.4
-pdf2image==1.16.3
-pillow==10.0.0
-pypdf==3.16.1
+    # via requests
+pymupdf==1.24.7
+    # via pdf2sb
+pymupdfb==1.24.6
+    # via pymupdf
 python-dateutil==2.8.2
+    # via python-gyazo
 python-gyazo==1.2.0
+    # via pdf2sb
 requests==2.31.0
+    # via python-gyazo
 six==1.16.0
-typing-extensions==4.8.0
+    # via python-dateutil
 urllib3==2.0.4
+    # via requests


### PR DESCRIPTION
Migrate libraries that extract data from PDF to MuPDF. This will eliminate the dependency on Poppler.