### PR TITLE
Update minimum python version to 3.10

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,7 +11,7 @@ jobs:
   test:
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.10", "3.11"]
         os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ dependencies = [
     "pymupdf>=1.24.7",
 ]
 readme = "README.md"
-requires-python = "~=3.8"
+requires-python = ">=3.10"
 
 [project.urls]
 Repository = "https://github.com/reiyw/pdf2sb"


### PR DESCRIPTION
## Summary
- drop support for Python 3.8/3.9
- update GitHub Actions CI matrix

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68412f26c1a4832bb2867cdf5c238dd6