### PR TITLE
Remove uv pip sync from CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,8 +20,6 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           enable-cache: true
-      - name: Install dependencies
-        run: uv pip sync requirements-dev.lock
       - name: Run pytest
         run: uv run pytest
   lint:
@@ -32,8 +30,6 @@ jobs:
         with:
           python-version: "3.10"
           enable-cache: true
-      - name: Install dependencies
-        run: uv pip sync requirements-dev.lock
       - name: Run mypy
         run: uv run mypy .
       - name: Run black


### PR DESCRIPTION
## Summary
- stop executing `uv pip sync` in CI jobs

## Testing
- `uv run pytest -q`
- `uv run mypy .`
- `uv run black . --check`
- `uv run ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68413b3c5a6c832b89ab18c1c78ec215